### PR TITLE
pluralize no public repo message

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -216,7 +216,7 @@ var run = function() {
                     });
                 } else {
                     $('#jobs').html('');
-                    $('#jobs').append('<p class="enlarge">I do not have any public repository. Sorry.</p>');
+                    $('#jobs').append('<p class="enlarge">I do not have any public repositories. Sorry.</p>');
                 }
             }
         });


### PR DESCRIPTION
A tiny grammatical error no one will ever see, but worth correcting anyway.
