### PR TITLE
Updated Error view

### DIFF
--- a/views/error.html
+++ b/views/error.html
@@ -3,7 +3,7 @@
    <div id="bd" role="main">
     <div class="yui-g">
         <p>
-           There was an issue accessing the requested profile to auto-generate a r&eacute;sum&eacute;. <a href="https://github.com/{{{username}}}" title="Github profile">Access the user's profile directly.</a>
+           There was an issue accessing the requested profile to auto-generate this r&eacute;sum&eacute;. <a href="https://github.com/{{{username}}}" title="Github profile">Access the user's profile directly.</a>
         </p>
     </div>
 


### PR DESCRIPTION
Changed the error page to redirect the visitor to the user's profile page inline with Brian Zeligson's suggestion from http://beezee.github.com/Development/2012/09/02/please-stop-breaking-my-github-profile/.
