### PR TITLE
Upgrade jQuery Library to support modern browsers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html lang="en">
 <head>
 	<title>Github R&eacute;sum&eacute;</title>
@@ -8,7 +8,7 @@
 	<link rel="stylesheet" type="text/css" href="http://yui.yahooapis.com/2.7.0/build/reset-fonts-grids/reset-fonts-grids.css" media="all" /> 
 	<link rel="stylesheet" type="text/css" href="css/resume.css" media="all" />
 	<link rel="stylesheet" type="text/css" href="css/print.css" media="print" />
-	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.0/jquery.min.js"></script>
+	<script type="text/javascript" src="http://code.jquery.com/jquery-1.8.1.min.js"></script>
 	<script type="text/javascript" src="js/mustache.js"></script>
 	<script type="text/javascript" src="js/githubresume.js"></script>
 </head>


### PR DESCRIPTION
The existing library breaks IE10 since the shim layer for jQuery 1.5 is
pretty cold and has significantly changed to be a lot better. I moved to
the jquery CDN since Google's CDN is really flaky and the 1.8.1 is
retuning error pages on that CDN.

Fixes #40
