### PR TITLE
Update language on error template to match master branch

### DIFF
--- a/views/error.html
+++ b/views/error.html
@@ -3,7 +3,7 @@
    <div id="bd" role="main">
     <div class="yui-g">
         <p>
-           here was an issue accessing the requested profile to auto-generate this r&eacute;sum&eacute;. <a href="https://github.com/{{{username}}}" title="Github profile">Access the user's profile directly.</a>
+           There was an issue accessing the requested profile to auto-generate this r&eacute;sum&eacute;. <a href="https://github.com/{{{username}}}" title="Github profile">Access the user's profile directly.</a>
         </p>
     </div>
 


### PR DESCRIPTION
The language on the gh-pages branch blames the github user you're attempting to view on $(window).error - the language in the master branch is much better. This just updates the gh-pages branch to match the master.
