### PR TITLE
Use plural form for zero

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -311,8 +311,8 @@ var run = function() {
                             username: username,
                             watchers: repo.info.watchers,
                             forks: repo.info.forks,
-                            watchersLabel: repo.info.watchers > 1 ? 'watchers' : 'watcher',
-                            forksLabel: repo.info.forks > 1 ? 'forks' : 'fork',
+                            watchersLabel: repo.info.watchers == 1 ? 'watcher' : 'watchers',
+                            forksLabel: repo.info.forks == 1 ? 'fork' : 'forks',
                         };
 
                         if (itemCount == sorted.length - 1 || itemCount == maxItems - 1) {


### PR DESCRIPTION
> This repository has 4 watchers and 0 fork.

In English zero should be plural: 0 forks
