### PR TITLE
Restore gists number on statusScore - Fix #57

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -153,8 +153,8 @@ var run = function() {
             var FIFTH_STEP = 150;
             var EXTRA_POINT_GAIN = 1;
             
-            var statusScore = view.repos * COEF_REPOS 
-                            + data.public_repos * COEF_GISTS 
+            var statusScore = data.public_repos * COEF_REPOS 
+                            + data.public_gists * COEF_GISTS 
                             + data.followers * COEF_FOLLOWERS 
                             + data.following * COEF_FOLLOWING;
             


### PR DESCRIPTION
We've got an issue on statusScore when using the number of gists, as explained by @markoheijnen on #57.
And here's the related fix!
