### PR TITLE
Remove useless padding-right

### DIFF
--- a/css/resume.css
+++ b/css/resume.css
@@ -110,7 +110,6 @@ h4 {  color: #333 }
 p {
   font-size: 100%;
   line-height: 18px;
-  padding-right: 3em;
 }
 
 a {  color: #990003 }
@@ -126,7 +125,6 @@ li {
 
 p.enlarge {
   font-size: 144%;
-  padding-right: 6.5em;
   line-height: 24px;
 }
 


### PR DESCRIPTION
Hi,

I notice two useless padding on p elements that causes an empty gutter on right.
Here's a tiny PR to remove them and restore the horizontal centering.

/ Eric
