### PR TITLE
Update public repositories link URL

### DIFF
--- a/views/resume.html
+++ b/views/resume.html
@@ -39,7 +39,7 @@
 								 {{#location}}
 								 based in <span class="adr locality">{{location}}</span>
 								 {{/location}}
-								 {{#repos}}with <a href="https://github.com/{{{username}}}">{{repos}} public {{reposLabel}}</a>{{/repos}}{{^repos}}without any public repository for now{{/repos}}{{#followers}}&nbsp;and <a href="https://github.com/{{{username}}}/followers">{{followers}} {{followersLabel}}</a>{{/followers}}.
+								 {{#repos}}with <a href="https://github.com/{{{username}}}?tab=repositories">{{repos}} public {{reposLabel}}</a>{{/repos}}{{^repos}}without any public repository for now{{/repos}}{{#followers}}&nbsp;and <a href="https://github.com/{{{username}}}/followers">{{followers}} {{followersLabel}}</a>{{/followers}}.
 								 I've been using github.com since {{since}}{{#earlyAdopter}}, therefore I'm an early adopter,{{/earlyAdopter}}
 								 {{#blog}}&nbsp;and sometimes I blog at <a href="{{blog}}" id="myblog" title="my blog">{{blog}}</a>.{{/blog}}
 							</p>

--- a/views/resumeOrgs.html
+++ b/views/resumeOrgs.html
@@ -36,7 +36,7 @@
 								 based in {{location}}
 								 {{/location}}
 								 {{#repos}} 
-                 with <a href="https://github.com/{{{username}}}">{{repos}} public {{reposLabel}}</a>
+                 with <a href="https://github.com/{{{username}}}?tab=repositories">{{repos}} public {{reposLabel}}</a>
                  {{/repos}}
                  {{#followers}}&nbsp;and <a href="https://github.com/{{{username}}}/followers">{{followers}} {{followersLabel}}</a>{{/followers}}.
 				 We created this GitHub group in {{since}}{{#earlyAdopter}}, therefore we're early adopters,{{/earlyAdopter}}{{#blog}}&nbsp;and you can find more informations about us at <a href="{{blog}}" id="myblog" title="my blog">{{blog}}</a>{{/blog}}.


### PR DESCRIPTION
Since [introduction of the "Contributions" tab](https://github.com/blog/1360-introducing-contributions) we don't get repositories list unless changing tab on users profile.

Therefore I update repositories list's link to immediately access to this content
