### PR TITLE
Github founders are also early adopters (before 2008)

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -136,7 +136,7 @@ var run = function() {
         };
         
         // We consider a limit of 4 months since the GitHub opening (Feb 2008) to be considered as an early adopter
-        if (since == '2008' && sinceMonth <= 5) {
+        if ((since == '2008' && sinceMonth <= 5) || since <= '2007') {
             view.earlyAdopter = 1;
         }
 		


### PR DESCRIPTION
With the current code Github founders are not considered early adopters. See: resume.github.io/?mojombo

He joined Github in 2007 which is before february 2008, the current threshold. 
