### PR TITLE
Added a check for the opt.in for in the users repositories

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -224,9 +224,14 @@ var run = function() {
     github_user_repos(username, function(data) {
         var sorted = [],
             languages = {},
+			optedIn = false,
             popularity;
 
+			
         $.each(data, function(i, repo) {
+			if (repo.name == 'github.resume.opt_in') {
+				optedIn = true;
+			}
             if (repo.fork !== false) {
                 return;
             }
@@ -242,7 +247,9 @@ var run = function() {
             popularity = repo.watchers + repo.forks;
             sorted.push({position: i, popularity: popularity, info: repo});
         });
-
+		if (!optedIn)
+			throw 'User has not opted in to this service.';
+			
         function sortByPopularity(a, b) {
             return b.popularity - a.popularity;
         };


### PR DESCRIPTION
This is the simplest thing I could see working for a basic serverless opt.in strategy.
I would just transfer ownership of this repo to you or you could create an empty repo and change the name.
https://github.com/nisbus/resume.github.com.opt.in

BTW sorry for the indentation, Emacs insisted to keep it like this :).

Cheers,
   nisbus
