### PR TITLE
Slight semantic fix for "I do not have any public repositories. Sorry" message

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -373,9 +373,9 @@ var run = function() {
                     });
                 } else {
                     if(data.length > 0){
-                      $('#jobs').html('').append('<p class="enlarge">All my repositories are forks. Sorry.</p>');
+                      $('#jobs').html('').append('<p class="enlarge">All of this user\'s repositories seem to be forks. Sorry.</p>');
                     } else {
-                      $('#jobs').html('').append('<p class="enlarge">I do not have any public repositories. Sorry.</p>');
+                      $('#jobs').html('').append('<p class="enlarge">Unfortunately, this user does not seem to have any <strong>public</strong> repositories.</p>');
                     }
                 }
             }


### PR DESCRIPTION
In the "GitHub Profile" section, it will display "$user is a developer with X public repositories. ..."

However, if the user in question only has other people's forks, it will display "I have no public repositories. Sorry". Two conflicting statements.

The section now states "All my repositories are forks" if that's the case. Perhaps that's not ideal, but I think it's better than what's there now.

You can test with my alter-ego, http://resume.github.io/?another-leprechaun
