### PR TITLE
Changes all references of 'blog' to 'website' instead.

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -226,7 +226,7 @@ var run = function() {
         };
 		
         if (data.blog !== undefined && data.blog !== null && data.blog !== '') {
-            view.blog = addHttp + data.blog;
+            view.website = addHttp + data.blog;
         }
 
         var resume = (data.type == 'User' ? 'views/resume.html' : 'views/resumeOrgs.html');

--- a/views/resume.html
+++ b/views/resume.html
@@ -43,16 +43,16 @@
 							</p>
 						</div>
 					</div><!--// .yui-gf -->
-					{{#blog}}
-					<div class="yui-gf" id="myblog">
+					{{#website}}
+					<div class="yui-gf" id="mywebsite">
 						<div class="yui-u first">
-							<h2>Blog</h2>
+							<h2>Website</h2>
 						</div>
-						<div class="yui-u" id="content-blog">
-							<a href="{{blog}}" id="myblog" title="{{name}}'s blog">{{blog}}</a>
+						<div class="yui-u" id="content-website">
+							<a href="{{website}}" id="mywebsite" title="{{name}}'s website">{{website}}</a>
 						</div>
 					</div>
-					{{/blog}}
+					{{/website}}
                     <div class="yui-gf" id="mylanguages">
                         <div class="yui-u first">
                             <h2>Languages</h2>

--- a/views/resumeOrgs.html
+++ b/views/resumeOrgs.html
@@ -39,7 +39,7 @@
                  with <a href="https://github.com/{{{username}}}?tab=repositories">{{repos}} public {{reposLabel}}</a>
                  {{/repos}}
                  {{#followers}}&nbsp;and <a href="https://github.com/{{{username}}}/followers">{{followers}} {{followersLabel}}</a>{{/followers}}.
-				 We created this GitHub group in {{since}}{{#earlyAdopter}}, therefore we're early adopters,{{/earlyAdopter}}{{#blog}}&nbsp;and you can find more information about us at <a href="{{blog}}" id="myblog" title="my blog">{{blog}}</a>{{/blog}}.
+				 We created this GitHub group in {{since}}{{#earlyAdopter}}, therefore we're early adopters,{{/earlyAdopter}}{{#website}}&nbsp;and you can find more information about us at <a href="{{website}}" id="mywebsite" title="my website">{{website}}</a>{{/website}}.
 							</p>
 							<p id="languages" class="enlarge"></p>
 						</div>


### PR DESCRIPTION
Since the wide majority of GitHub users provide something other than a blog in the place to provide a personal URL, I think it would make more sense to refer to it as a website, and not a blog :)
