### PR TITLE
Fixed links in "Languages" section

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -300,7 +300,9 @@ var run = function() {
                     name: lang,
                     popularity: languages[lang],
                     toString: function() {
-                        return '<a href="https://github.com/languages/' + this.name + '">' + this.name + '</a>';
+                        return '<a href="https://github.com/search?q=user%3A'
+                            + username + '&type=Repositories&ref=advsearch&l='
+                            + this.name + '">'+ this.name + '</a>';
                     }
                 });
 


### PR DESCRIPTION
Was previously leading to 404, I think pointing to the list of users repos using the targeted language makes sens.