### PR TITLE
Show error page on request error

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -94,7 +94,8 @@ var github_user_starred_resume = function(username, page) {
         dataType: 'json',
         success: function(data) {
             repos = data;
-        }
+        },
+        error: error
     });
 
     $.each(repos, function(i, repo) {


### PR DESCRIPTION
Previously, if there was an error with the API, for instance a request limit, it would show that the used hasn't opt-in. Now it shows the error page.