### PR TITLE
Use dashes instead of hyphens where appropriate

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -362,7 +362,7 @@ var run = function() {
                         if (since == until) {
                             date = since;
                         } else {
-                            date = since + ' - ' + until;
+                            date = since + ' &endash; ' + until;
                         }
 
                         view = {

--- a/views/job.html
+++ b/views/job.html
@@ -2,7 +2,7 @@
   <h2>
     <a href="https://github.com/{{username}}/{{name}}">{{name}}</a>
   </h2>
-  <h3>{{#language}}{{language}} - {{/language}}Creator &amp; Owner</h3>
+  <h3>{{#language}}{{language}} &endash; {{/language}}Creator &amp; Owner</h3>
   <h4>{{date}}</h4>
   <p>{{description}}</p>
   <p>


### PR DESCRIPTION
Hyphens are only ever to be used to hyphenate words – they are not punctuation.