### PR TITLE
Updated link for language in resume page from

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -300,7 +300,7 @@ var run = function() {
                     name: lang,
                     popularity: languages[lang],
                     toString: function() {
-                        return '<a href="https://github.com/languages/' + this.name + '">' + this.name + '</a>';
+                        return '<a href="https://en.wikipedia.org/wiki/' + this.name + '_(programming_language)">' + this.name + '</a>';
                     }
                 });
 


### PR DESCRIPTION
Changed the link for language in resume page from  www.github.com/languages/lang to en.wikipedia.org/wiki/lang_(programming_language).

That url wasn't working and wikipedia has consistent format of link for programming languages.