### PR TITLE
Use GitHub's language trending page for language links

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -300,7 +300,7 @@ var run = function() {
                     name: lang,
                     popularity: languages[lang],
                     toString: function() {
-                        return '<a href="https://github.com/languages/' + this.name + '">' + this.name + '</a>';
+                        return '<a href="https://github.com/trending?l=' + this.name + '">' + this.name + '</a>';
                     }
                 });
 


### PR DESCRIPTION
Previous link was broken.

e.g

https://github.com/languages/Rust (broken)
v.
https://github.com/trending?l=Rust
