### PR TITLE
Fix processing empty descriptions for private repositories

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -419,7 +419,8 @@ var run = function() {
                         var emojiPattern = /:([a-z0-9_\+\-]+):/g;
                         // no, it's not really a pattern
                         var imagePattern = "<img width='20' height='20' src='https://assets-cdn.github.com/images/icons/emoji/$1.png' />";
-                        repo.info.description = repo.info.description.replace(emojiPattern, imagePattern);
+                        var description = repo.info.description;
+                        repo.info.description = description ? description.replace(emojiPattern, imagePattern): description;
                         view = {
                             name: repo.info.name,
                             date: date,

--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -420,7 +420,7 @@ var run = function() {
                         // no, it's not really a pattern
                         var imagePattern = "<img width='20' height='20' src='https://assets-cdn.github.com/images/icons/emoji/$1.png' />";
                         var description = repo.info.description;
-                        repo.info.description = description ? description.replace(emojiPattern, imagePattern): description;
+                        repo.info.description = description ? description.replace(emojiPattern, imagePattern) : description;
                         view = {
                             name: repo.info.name,
                             date: date,


### PR DESCRIPTION
While attempting to play with this, I was unable to generate my own resume.

The issue is that private repositories appear to lack a description, which ends up breaking the resume generation [here](https://github.com/resume/resume.github.com/blob/master/js/githubresume.js#L422).

This fixes it.