### PR TITLE
Fix broken languages link

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -353,7 +353,7 @@ var run = function() {
                     popularity: languages[lang],
                     toString: function() {
                         return '<a href="https://github.com/search?q=user%3A'
-                            + username + '&l=' + this.name + '">'
+                            + username + '&l=' + encodeURIComponent(this.name) + '">'
                             + this.name + '</a>';
                     }
                 });


### PR DESCRIPTION
This especially broke the link when the language is C++ because the + characters weren't encoded properly