### PR TITLE
feat: List all user repos(owner + member)

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -59,7 +59,7 @@ var github_user = function(username, callback) {
 
 var github_user_repos = function(username, callback, page_number, prev_data) {
     var page = (page_number ? page_number : 1),
-        url = 'https://api.github.com/users/' + username + '/repos?per_page=100&callback=?',
+        url = 'https://api.github.com/users/' + username + '/repos?type=all&per_page=100&callback=?',
         data = (prev_data ? prev_data : []);
 
     if (page_number > 1) {


### PR DESCRIPTION
Thank you for this awesome project!

I noticed that my GitHub resume did not list repos to which I had push access. 
- My resume link - http://resume.github.io/?sudo-suhas
- Unlisted repos:
  - https://github.com/davidtheclark/cosmiconfig
  - https://github.com/booleanapp/elastic-muto

I checked the [relevant GitHub documentation](https://developer.github.com/v3/repos/#list-user-repositories) and it has a query parameter to request all repos. This will include repos of which I am either 'owner' or 'member'.

This PR adds the query parameter to the API request. I was able to confirm the behavior with GET API requests:
- Default type - 'owner' - https://api.github.com/users/sudo-suhas/repos
- Type - 'all' - https://api.github.com/users/sudo-suhas/repos?type=all

I have not tested this locally but I am reasonably confident that this should work.