### PR TITLE
Fix followers 404

### DIFF
--- a/views/resume.html
+++ b/views/resume.html
@@ -39,7 +39,7 @@
                  {{#location}}
                  based in <span class="adr locality">{{location}}</span>
                  {{/location}}
-                 {{#repos}}with <a href="https://github.com/{{{username}}}?tab=repositories">{{repos}} public {{reposLabel}}</a>{{/repos}}{{^repos}}without any public repository for now{{/repos}}{{#followers}}&nbsp;and <a href="https://github.com/{{{username}}}/followers">{{followers}} {{followersLabel}}</a>{{/followers}}.
+                 {{#repos}}with <a href="https://github.com/{{{username}}}?tab=repositories">{{repos}} public {{reposLabel}}</a>{{/repos}}{{^repos}}without any public repository for now{{/repos}}{{#followers}}&nbsp;and <a href="https://github.com/{{{username}}}?tab=followers">{{followers}} {{followersLabel}}</a>{{/followers}}.
               </p>
             </div>
           </div><!--// .yui-gf -->


### PR DESCRIPTION
The current followers link results in a 404 (`/user/followers`), I changed it to `/user?tab=followers`. 