### PR TITLE
fix: generated github urls for language search should work

### DIFF
--- a/js/githubresume.js
+++ b/js/githubresume.js
@@ -353,7 +353,7 @@ var run = function() {
                     popularity: languages[lang],
                     toString: function() {
                         return '<a href="https://github.com/search?q=user%3A'
-                            + username + '&l=' + encodeURIComponent(this.name) + '">'
+                            + username + '+lang%3A' + encodeURIComponent(this.name) + '">'
                             + this.name + '</a>';
                     }
                 });


### PR DESCRIPTION
Generated urls look like:
https://github.com/search?q=user%3Aagentender&l=R
instead of:
https://github.com/search?q=user%3Aagentender+lang%3AR